### PR TITLE
feat: Add Data Lake Architecture Diagram

### DIFF
--- a/data-lake/aws_data_lake.py
+++ b/data-lake/aws_data_lake.py
@@ -1,0 +1,25 @@
+"""
+Diagram for a basic Data Lake Architecture on AWS.
+"""
+from diagrams import Cluster, Diagram
+from diagrams.aws.analytics import Glue, Redshift, QuickSight
+from diagrams.aws.storage import S3
+from diagrams.aws.database import DmsDatabaseMigrationService as DMS
+
+with Diagram("AWS Data Lake Architecture", show=False):
+    
+    source = DMS("Data Source (e.g., DB)")
+
+    with Cluster("Data Lake"):
+        s3_raw = S3("Raw Zone (S3)")
+        
+        with Cluster("ETL & Warehouse"):
+            glue_etl = Glue("ETL (Glue)")
+            redshift_dw = Redshift("Warehouse (Redshift)")
+        
+        s3_raw >> glue_etl >> redshift_dw
+
+    bi_tool = QuickSight("BI (QuickSight)")
+    
+    source >> s3_raw
+    redshift_dw >> bi_tool

--- a/disaster-recovery/aws_disaster_recovery.py
+++ b/disaster-recovery/aws_disaster_recovery.py
@@ -1,0 +1,36 @@
+"""
+Diagram for a Multi-Region Disaster Recovery (DR) Architecture on AWS.
+"""
+from diagrams import Cluster, Diagram, Edge
+from diagrams.aws.network import Route53
+from diagrams.aws.compute import EC2
+from diagrams.aws.database import RDS
+from diagrams.aws.storage import S3
+
+with Diagram("AWS Multi-Region DR Architecture", show=False):
+
+    dns = Route53("DNS (Route 53)")
+
+    with Cluster("Region 1 (Primary - us-east-1)"):
+        primary_ec2 = EC2("App Server")
+        primary_db = RDS("Primary DB")
+        primary_s3 = S3("Primary S3 Bucket")
+
+    with Cluster("Region 2 (Standby - us-west-2)"):
+        standby_ec2 = EC2("Standby Server")
+        standby_db = RDS("Read Replica DB")
+        standby_s3 = S3("Replicated S3 Bucket")
+
+    # Traffic Flow
+    dns >> primary_ec2
+    primary_ec2 >> primary_db
+    primary_ec2 >> primary_s3
+
+    # Replication Links (Data Sync)
+    primary_db >> Edge(label="Replication", style="dotted") >> standby_db
+    primary_s3 >> Edge(label="CRR", style="dotted") >> standby_s3
+
+    # Standby Flow (if primary fails, DNS points here)
+    dns >> Edge(label="Failover", style="dashed", color="red") >> standby_ec2
+    standby_ec2 >> standby_db
+    standby_ec2 >> standby_s3


### PR DESCRIPTION
Adds the Python script for generating the AWS Data Lake diagram. Closes #11 #hacktoberfest.